### PR TITLE
Add configuration settings for Chicken Breeder and Roost speeds

### DIFF
--- a/src/main/java/com/timwoodcreates/roost/Roost.java
+++ b/src/main/java/com/timwoodcreates/roost/Roost.java
@@ -11,7 +11,7 @@ import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLInterModComms;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
-@Mod(modid = Roost.MODID, version = Roost.VERSION)
+@Mod(modid = Roost.MODID, version = Roost.VERSION, guiFactory = "com.timwoodcreates.roost.config.ConfigurationGuiFactory")
 public class Roost {
 	public static final String MODID = "roost";
 	public static final String NAME = "Roost";

--- a/src/main/java/com/timwoodcreates/roost/Roost.java
+++ b/src/main/java/com/timwoodcreates/roost/Roost.java
@@ -1,5 +1,6 @@
 package com.timwoodcreates.roost;
 
+import com.timwoodcreates.roost.config.ConfigurationHandler;
 import com.timwoodcreates.roost.proxy.ProxyCommon;
 
 import net.minecraft.creativetab.CreativeTabs;
@@ -16,6 +17,7 @@ public class Roost {
 	public static final String NAME = "Roost";
 	public static final String VERSION = "@VERSION@";
 	public static final CreativeTabs TAB = new RoostTab();
+	public static ConfigurationHandler config;
 
 	@Instance(MODID)
 	public static Roost INSTANCE;

--- a/src/main/java/com/timwoodcreates/roost/config/ConfigurationGuiFactory.java
+++ b/src/main/java/com/timwoodcreates/roost/config/ConfigurationGuiFactory.java
@@ -1,0 +1,27 @@
+package com.timwoodcreates.roost.config;
+
+import com.timwoodcreates.roost.Roost;
+
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.common.config.ConfigCategory;
+import net.minecraftforge.common.config.ConfigElement;
+import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fml.client.DefaultGuiFactory;
+import net.minecraftforge.fml.client.config.GuiConfig;
+import net.minecraftforge.fml.client.config.IConfigElement;
+
+import java.util.List;
+
+public class ConfigurationGuiFactory extends DefaultGuiFactory {
+	public ConfigurationGuiFactory() {
+		super(Roost.MODID, GuiConfig.getAbridgedConfigPath(ConfigurationHandler.config.toString()));
+	}
+
+	@Override
+	public GuiScreen createConfigGui(GuiScreen parent) {
+		final ConfigCategory category = ConfigurationHandler.config.getCategory(Configuration.CATEGORY_GENERAL);
+		final List<IConfigElement> elements = new ConfigElement(category).getChildElements();
+
+		return new GuiConfig(parent, elements, this.modid, false, false, this.title);
+	}
+}

--- a/src/main/java/com/timwoodcreates/roost/config/ConfigurationHandler.java
+++ b/src/main/java/com/timwoodcreates/roost/config/ConfigurationHandler.java
@@ -2,8 +2,13 @@ package com.timwoodcreates.roost.config;
 
 import java.io.File;
 
+import com.timwoodcreates.roost.Roost;
+
 import net.minecraft.client.resources.I18n;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fml.client.event.ConfigChangedEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class ConfigurationHandler {
 	public static Configuration config;
@@ -11,6 +16,8 @@ public class ConfigurationHandler {
 	public static float speedRoost = 1f;
 
 	public ConfigurationHandler(File configFile) {
+		MinecraftForge.EVENT_BUS.register(this);
+
 		config = new Configuration(configFile);
 		config.load();
 
@@ -23,6 +30,13 @@ public class ConfigurationHandler {
 
 		if (config.hasChanged()) {
 			config.save();
+		}
+	}
+
+	@SubscribeEvent
+	public void onConfigChanged(ConfigChangedEvent.OnConfigChangedEvent e) {
+		if (e.getModID().equalsIgnoreCase(Roost.MODID)) {
+			update();
 		}
 	}
 }

--- a/src/main/java/com/timwoodcreates/roost/config/ConfigurationHandler.java
+++ b/src/main/java/com/timwoodcreates/roost/config/ConfigurationHandler.java
@@ -1,0 +1,28 @@
+package com.timwoodcreates.roost.config;
+
+import java.io.File;
+
+import net.minecraft.client.resources.I18n;
+import net.minecraftforge.common.config.Configuration;
+
+public class ConfigurationHandler {
+	public static Configuration config;
+	public static float speedBreeder = 1f;
+	public static float speedRoost = 1f;
+
+	public ConfigurationHandler(File configFile) {
+		config = new Configuration(configFile);
+		config.load();
+
+		update();
+	}
+
+	private static void update() {
+		speedBreeder = config.getFloat("roost.speedBreeder", Configuration.CATEGORY_GENERAL, speedBreeder, Float.MIN_VALUE, Float.MAX_VALUE, I18n.format("config.speed.breeder"));
+		speedRoost = config.getFloat("roost.speedRoost", Configuration.CATEGORY_GENERAL, speedRoost, Float.MIN_VALUE, Float.MAX_VALUE, I18n.format("config.speed.roost"));
+
+		if (config.hasChanged()) {
+			config.save();
+		}
+	}
+}

--- a/src/main/java/com/timwoodcreates/roost/proxy/ProxyCommon.java
+++ b/src/main/java/com/timwoodcreates/roost/proxy/ProxyCommon.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.timwoodcreates.roost.Roost;
 import com.timwoodcreates.roost.RoostBlocks;
 import com.timwoodcreates.roost.RoostItems;
+import com.timwoodcreates.roost.config.ConfigurationHandler;
 import com.timwoodcreates.roost.gui.GuiHandler;
 import com.timwoodcreates.roost.tileentity.TileEntityBreeder;
 import com.timwoodcreates.roost.tileentity.TileEntityCollector;
@@ -33,6 +34,8 @@ public class ProxyCommon {
 
 	public void preInit(FMLPreInitializationEvent e) {
 		NetworkRegistry.INSTANCE.registerGuiHandler(Roost.INSTANCE, new GuiHandler());
+
+		Roost.config = new ConfigurationHandler(e.getSuggestedConfigurationFile());
 
 		registerBlocks();
 		registerItems();

--- a/src/main/java/com/timwoodcreates/roost/tileentity/TileEntityBreeder.java
+++ b/src/main/java/com/timwoodcreates/roost/tileentity/TileEntityBreeder.java
@@ -27,6 +27,19 @@ public class TileEntityBreeder extends TileEntityChickenContainer {
 	private static final String HAS_SEEDS_KEY = "HasSeeds";
 
 	@Override
+	protected void resetTimer() {
+		super.resetTimer();
+
+		float multiplier = Roost.config.speedBreeder;
+
+		if (multiplier <= 0) {
+			multiplier = Float.MIN_VALUE;
+		}
+
+		timeUntilNextDrop /= multiplier;
+	}
+
+	@Override
 	protected void isFullOfChickensChanged(boolean isFull) {
 		BlockBreeder.setIsBreedingState(isFull, getWorld(), pos);
 	}

--- a/src/main/java/com/timwoodcreates/roost/tileentity/TileEntityChickenContainer.java
+++ b/src/main/java/com/timwoodcreates/roost/tileentity/TileEntityChickenContainer.java
@@ -29,7 +29,7 @@ public abstract class TileEntityChickenContainer extends TileEntity implements I
 	private NonNullList<ItemStack> inventory = NonNullList.<ItemStack>withSize(getSizeInventory(), ItemStack.EMPTY);
 	private boolean mightNeedToUpdateChickenInfo = true;
 	private boolean skipNextTimerReset = false;
-	private int timeUntilNextDrop = 0;
+	protected int timeUntilNextDrop = 0;
 	private int timeElapsed = 0;
 
 	private DataChicken[] chickenData = new DataChicken[getSizeChickenInventory()];
@@ -125,7 +125,7 @@ public abstract class TileEntityChickenContainer extends TileEntity implements I
 		}
 	}
 
-	private void resetTimer() {
+	protected void resetTimer() {
 		timeElapsed = 0;
 		timeUntilNextDrop = 0;
 		for (int i = 0; i < chickenData.length; i++) {

--- a/src/main/java/com/timwoodcreates/roost/tileentity/TileEntityRoost.java
+++ b/src/main/java/com/timwoodcreates/roost/tileentity/TileEntityRoost.java
@@ -25,6 +25,19 @@ public class TileEntityRoost extends TileEntityChickenContainer {
 	private static int CHICKEN_SLOT = 0;
 
 	@Override
+	protected void resetTimer() {
+		super.resetTimer();
+
+		float multiplier = Roost.config.speedRoost;
+
+		if (multiplier <= 0) {
+			multiplier = Float.MIN_VALUE;
+		}
+
+		timeUntilNextDrop /= multiplier;
+	}
+
+	@Override
 	protected void isFullOfChickensChanged(boolean isFull) {
 		notifyBlockUpdate();
 	}

--- a/src/main/resources/assets/roost/lang/en_us.lang
+++ b/src/main/resources/assets/roost/lang/en_us.lang
@@ -23,3 +23,6 @@ item.roost.chicken.spawning.normal=Found in the overworld
 item.roost.chicken.spawning.snow=Found in snowy biomes
 
 itemGroup.roost=Roost
+
+config.speed.breeder=The speed multiplier for the breeder.  Higher is faster.
+config.speed.roost=The speed multiplier for the roost.  Higher is faster.


### PR DESCRIPTION
I found myself wanting to adjust the speed of Chicken Breeders for a modpack I'm working on, so created a configuration file for adjusting it.  (And also Roost speed, because it was easy.)  Both settings are floats which multiply the speed of the block (i.e. divide the time until next drop) and they can also be adjusted in the Mod Options GUI.