### PR TITLE
Add stat inheritance with config options

### DIFF
--- a/src/main/java/com/timwoodcreates/roost/RoostConfig.java
+++ b/src/main/java/com/timwoodcreates/roost/RoostConfig.java
@@ -22,6 +22,15 @@ public class RoostConfig {
 	@RangeDouble(min = 0.01d, max = 100d)
 	public static double breederSpeed = 1d;
 
+	@Comment("Enables stat inheritance when crossbreeding.")
+	public static boolean breederInheritanceEnabled = false;
+
+	@Comment({"The ratio at which stats are inherited.",
+                 "1.0 = average of parent's stats.",
+                 "0.5 = 50% of the average."})
+	@RangeDouble(min = 0.1d, max = 1d)
+	public static double breederInheritanceRatio = 1d;
+
 	public static void sync() {
 		ConfigManager.sync(Roost.MODID, Config.Type.INSTANCE);
 	}

--- a/src/main/java/com/timwoodcreates/roost/data/DataChicken.java
+++ b/src/main/java/com/timwoodcreates/roost/data/DataChicken.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import java.util.regex.Pattern;
 
 import com.google.common.base.CaseFormat;
+import com.timwoodcreates.roost.RoostConfig;
 import com.timwoodcreates.roost.RoostItems;
 
 import net.minecraft.client.resources.I18n;
@@ -126,6 +127,15 @@ public class DataChicken {
 		if (parentA == null || parentB == null) return ItemStack.EMPTY;
 		DataChicken childData = DataChicken.getDataFromEntity(parentA.createChild(parentB));
 		if (childData == null) return ItemStack.EMPTY;
+
+		if (RoostConfig.breederInheritanceEnabled &&
+			childData instanceof DataChickenModded &&
+			chickenA instanceof DataChickenModded &&
+			chickenB instanceof DataChickenModded) {
+
+			((DataChickenModded) childData).inheritParents((DataChickenModded) chickenA, (DataChickenModded) chickenB);
+		}
+
 		return childData.buildChickenStack();
 	}
 

--- a/src/main/java/com/timwoodcreates/roost/data/DataChickenModded.java
+++ b/src/main/java/com/timwoodcreates/roost/data/DataChickenModded.java
@@ -13,6 +13,7 @@ import com.setycz.chickens.handler.SpawnType;
 import com.setycz.chickens.item.ItemSpawnEgg;
 import com.setycz.chickens.registry.ChickensRegistry;
 import com.setycz.chickens.registry.ChickensRegistryItem;
+import com.timwoodcreates.roost.RoostConfig;
 import com.timwoodcreates.roost.RoostItems;
 
 import net.minecraft.entity.Entity;
@@ -52,6 +53,18 @@ public class DataChickenModded extends DataChicken {
 		if (chicken != null) return new DataChickenModded(chicken, stack.getTagCompound());
 
 		return null;
+	}
+
+	public void inheritParents(DataChickenModded p1, DataChickenModded p2) {
+		String p1_type = p1.getChickenType();
+		String p2_type = p2.getChickenType();
+		String ct = getChickenType();
+
+		if (!ct.equals(p1_type) && !ct.equals(p2_type) && !p1_type.equals(p2_type)) {
+			gain = Math.max((int) (((p1.gain + p2.gain) / 2.0) * RoostConfig.breederInheritanceRatio), 1);
+			growth = Math.max((int) (((p1.growth + p2.growth) / 2.0) * RoostConfig.breederInheritanceRatio), 1);
+			strength = Math.max((int) (((p1.strength + p2.strength) / 2.0) * RoostConfig.breederInheritanceRatio), 1);
+		}
 	}
 
 	public static void addAllChickens(List<DataChicken> chickens) {


### PR DESCRIPTION
Hello,

This is a small change which adds support for stat inheritance when crossbreeding. It uses two config options, one boolean for enable/disable and one double for the ratio at which parent stats are inherited by children (1.0 = child get parent average for each stat).

I used this in a playthrough recently and just thought I'd see what you think about it.